### PR TITLE
Fix strtolower usage with null argument

### DIFF
--- a/lib/Horde/String.php
+++ b/lib/Horde/String.php
@@ -195,7 +195,7 @@ class Horde_String
         if (!isset(self::$_lowers[$string])) {
             $language = setlocale(LC_CTYPE, 0);
             setlocale(LC_CTYPE, 'C');
-            self::$_lowers[$string] = strtolower($string);
+            self::$_lowers[$string] = $string === null ? '' : strtolower($string);
             setlocale(LC_CTYPE, $language);
         }
 


### PR DESCRIPTION
Ref https://github.com/bytestream/Mime/pull/4#issuecomment-1137143531

Lowering null results in an empty string: https://3v4l.org/jF91B