### PR TITLE
Require Mbstring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-dom": "*",
-        "symfony/polyfill-php72": "^1.27"
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
symfony/polyfill-php72 1.31.0 removed the polyfill file. We could require 1.30.0 but I think that's just delaying the problem.

I've required mbstring because it's needed in both the `length()` and `_convertCharset()` function.