### PR TITLE
Fix deprecation warnings on PHP >= 8.5

### DIFF
--- a/lib/Horde/String.php
+++ b/lib/Horde/String.php
@@ -164,10 +164,12 @@ class Horde_String
             return strtolower($string);
         }
 
+        $string = $string ?? '';
+
         if (!isset(self::$_lowers[$string])) {
             $language = setlocale(LC_CTYPE, 0);
             setlocale(LC_CTYPE, 'C');
-            self::$_lowers[$string] = $string === null ? '' : strtolower($string);
+            self::$_lowers[$string] = strtolower($string);
             setlocale(LC_CTYPE, $language);
         }
 


### PR DESCRIPTION
When running the unit tests of https://github.com/bytestream/Mime, the following deprecation warnings appear:

```
Deprecated: Using null as an array offset is deprecated, use an empty string instead in /root/Mime/vendor/bytestream/horde-util/lib/Horde/String.php on line 167

Deprecated: Using null as an array offset is deprecated, use an empty string instead in /root/Mime/vendor/bytestream/horde-util/lib/Horde/String.php on line 170

Deprecated: Using null as an array offset is deprecated, use an empty string instead in /root/Mime/vendor/bytestream/horde-util/lib/Horde/String.php on line 174
```

That's fixed by this PR. I'm not sure if the `strtolower($string)` call could be moved before the `if` switch as well, but I wanted to prevent changing the flow itself too much.

Relates to https://github.com/bytestream/Mime/pull/11.